### PR TITLE
Add SwiftUI skeleton app with ChatGPT agent

### DIFF
--- a/QuantTradingApp/ContentView.swift
+++ b/QuantTradingApp/ContentView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var agent = TradingAgent()
+    @State private var query: String = "latest trading strategies"
+    @State private var response: String = ""
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading) {
+                TextField("Ask ChatGPT", text: $query)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Run Query") {
+                    agent.askChatGPT(prompt: query) { result in
+                        switch result {
+                        case .success(let text):
+                            response = text
+                        case .failure(let error):
+                            response = error.localizedDescription
+                        }
+                    }
+                }
+                .padding(.vertical)
+
+                ScrollView {
+                    Text(response)
+                        .padding()
+                }
+            }
+            .padding()
+            .navigationTitle("Quant Trading")
+            .onAppear {
+                agent.loadSP500()
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/QuantTradingApp/OpenAIService.swift
+++ b/QuantTradingApp/OpenAIService.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct OpenAIService {
+    let apiKey: String
+
+    func chatCompletion(prompt: String, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "model": "gpt-3.5-turbo",
+            "messages": [["role": "user", "content": prompt]]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let data = data else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data"])))
+                return
+            }
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let choices = json["choices"] as? [[String: Any]],
+               let message = choices.first?["message"] as? [String: Any],
+               let content = message["content"] as? String {
+                completion(.success(content.trimmingCharacters(in: .whitespacesAndNewlines)))
+            } else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])))
+            }
+        }.resume()
+    }
+}

--- a/QuantTradingApp/QuantTradingAppApp.swift
+++ b/QuantTradingApp/QuantTradingAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct QuantTradingAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/QuantTradingApp/StockDataService.swift
+++ b/QuantTradingApp/StockDataService.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct StockDataService {
+    func fetchQuote(symbol: String, completion: @escaping (Result<Double, Error>) -> Void) {
+        // Placeholder for fetching stock price
+        // In a real app, integrate with a financial data API
+        completion(.success(Double.random(in: 100...500)))
+    }
+}

--- a/QuantTradingApp/TradingAgent.swift
+++ b/QuantTradingApp/TradingAgent.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+class TradingAgent: ObservableObject {
+    @Published var sp500Symbols: [String] = []
+    private var openAI: OpenAIService
+
+    init() {
+        // Set your API key here or load from environment
+        self.openAI = OpenAIService(apiKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? "")
+    }
+
+    func loadSP500() {
+        // Placeholder: In a real app, fetch the S&P 500 symbols from a data provider.
+        sp500Symbols = ["AAPL", "MSFT", "GOOGL"]
+    }
+
+    func askChatGPT(prompt: String, completion: @escaping (Result<String, Error>) -> Void) {
+        openAI.chatCompletion(prompt: prompt, completion: completion)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
-# Quant-Trading-App
+# Quant Trading iPhone App
 
-Algorithmic flows,
-Charts shimmer with bright signals,
-Profits bloom like spring.
+This repo contains a minimal SwiftUI skeleton for an iOS application that demonstrates how you might integrate OpenAI's ChatGPT with basic S&P 500 data.
+
+## Features
+
+- `TradingAgent` loads a small list of sample S&P 500 symbols.
+- `OpenAIService` sends prompts to ChatGPT via the OpenAI API.
+- The `ContentView` UI lets you type a question about trading strategies and displays ChatGPT's response.
+
+To build the app you need Xcode and an OpenAI API key available as the `OPENAI_API_KEY` environment variable.
+
+```bash
+# Example build (requires Xcode tools)
+xcodebuild -scheme QuantTradingApp
+```
+
+This is just a skeleton, so many parts such as fetching real market data or implementing advanced trading logic are left as placeholders.


### PR DESCRIPTION
## Summary
- build a minimal SwiftUI iPhone app for quant trading
- integrate a `TradingAgent` that queries ChatGPT via OpenAI API
- show placeholder S&P 500 symbols and stock data service
- update the README with build instructions

## Testing
- `swiftc QuantTradingApp/*.swift -parse`

------
https://chatgpt.com/codex/tasks/task_e_687b2b1ae0c08331a534082910c8cdcc