### PR TITLE
Add real market data integration

### DIFF
--- a/QuantTradingApp/ContentView.swift
+++ b/QuantTradingApp/ContentView.swift
@@ -4,6 +4,8 @@ struct ContentView: View {
     @StateObject private var agent = TradingAgent()
     @State private var query: String = "latest trading strategies"
     @State private var response: String = ""
+    @State private var symbol: String = "AAPL"
+    @State private var priceText: String = ""
 
     var body: some View {
         NavigationView {
@@ -21,6 +23,27 @@ struct ContentView: View {
                     }
                 }
                 .padding(.vertical)
+
+                HStack {
+                    TextField("Symbol", text: $symbol)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    Button("Get Price") {
+                        agent.fetchPrice(symbol: symbol) { result in
+                            switch result {
+                            case .success(let price):
+                                priceText = String(format: "%.2f", price)
+                            case .failure(let error):
+                                priceText = error.localizedDescription
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom)
+
+                if !priceText.isEmpty {
+                    Text("Latest price for \(symbol): \(priceText)")
+                        .padding(.bottom)
+                }
 
                 ScrollView {
                     Text(response)

--- a/QuantTradingApp/StockDataService.swift
+++ b/QuantTradingApp/StockDataService.swift
@@ -1,9 +1,41 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct StockDataService {
+    /// Fetch the latest quote for the given symbol using the Alpha Vantage API.
+    /// The API key is read from the `ALPHA_VANTAGE_API_KEY` environment variable
+    /// and falls back to Alpha Vantage's `demo` key for convenience.
     func fetchQuote(symbol: String, completion: @escaping (Result<Double, Error>) -> Void) {
-        // Placeholder for fetching stock price
-        // In a real app, integrate with a financial data API
-        completion(.success(Double.random(in: 100...500)))
+        let apiKey = ProcessInfo.processInfo.environment["ALPHA_VANTAGE_API_KEY"] ?? "demo"
+        guard let url = URL(string: "https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=\(symbol)&apikey=\(apiKey)") else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
+            return
+        }
+
+        let request = URLRequest(url: url)
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let data = data else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data"])))
+                return
+            }
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let quote = json["Global Quote"] as? [String: Any],
+                   let priceString = quote["05. price"] as? String,
+                   let price = Double(priceString) {
+                    completion(.success(price))
+                } else {
+                    completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])))
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
     }
 }

--- a/QuantTradingApp/TradingAgent.swift
+++ b/QuantTradingApp/TradingAgent.swift
@@ -3,10 +3,15 @@ import Foundation
 class TradingAgent: ObservableObject {
     @Published var sp500Symbols: [String] = []
     private var openAI: OpenAIService
+    private let stockService = StockDataService()
 
     init() {
         // Set your API key here or load from environment
         self.openAI = OpenAIService(apiKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? "")
+    }
+
+    func fetchPrice(symbol: String, completion: @escaping (Result<Double, Error>) -> Void) {
+        stockService.fetchQuote(symbol: symbol, completion: completion)
     }
 
     func loadSP500() {

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Quant Trading iPhone App
 
-This repo contains a minimal SwiftUI skeleton for an iOS application that demonstrates how you might integrate OpenAI's ChatGPT with basic S&P 500 data.
+This repo contains a minimal SwiftUI skeleton for an iOS application that demonstrates how you might integrate OpenAI's ChatGPT with basic S&P 500 data and live market quotes.
 
 ## Features
 
-- `TradingAgent` loads a small list of sample S&P 500 symbols.
+- `TradingAgent` loads a small list of sample S&P 500 symbols and can fetch real-time prices.
 - `OpenAIService` sends prompts to ChatGPT via the OpenAI API.
-- The `ContentView` UI lets you type a question about trading strategies and displays ChatGPT's response.
+- The `ContentView` UI lets you type a question about trading strategies and displays ChatGPT's response. It can also show the latest quote for a selected stock symbol.
 
-To build the app you need Xcode and an OpenAI API key available as the `OPENAI_API_KEY` environment variable.
+To build the app you need Xcode, an OpenAI API key available as the `OPENAI_API_KEY` environment variable, and an Alpha Vantage API key set as `ALPHA_VANTAGE_API_KEY` (it defaults to the public `demo` key).
 
 ```bash
 # Example build (requires Xcode tools)
 xcodebuild -scheme QuantTradingApp
 ```
 
-This is just a skeleton, so many parts such as fetching real market data or implementing advanced trading logic are left as placeholders.
+This is still a minimal skeleton, so advanced trading logic is left as a placeholder, but the app now includes a simple example of retrieving live quotes from the Alpha Vantage API.


### PR DESCRIPTION
## Summary
- fetch real stock quotes from the Alpha Vantage API
- expose price fetching via `TradingAgent`
- show a UI to request a symbol's latest price
- document new functionality and API key requirement
- add FoundationNetworking for Linux compatibility

## Testing
- `swiftc -c QuantTradingApp/StockDataService.swift -o /tmp/StockDataService.o`
- `swiftc -c QuantTradingApp/TradingAgent.swift` *(fails: cannot find modules such as ObservableObject)*

------
https://chatgpt.com/codex/tasks/task_e_687b2da980188331b36a3873d0f2d491